### PR TITLE
Python3.8 out of support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ keywords = ['unit', 'convert', 'time', 'timestamp', 'length']
 classifiers=[
     'License :: OSI Approved :: MIT License',
 
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
## Summary
- Python3.8 out of support.