### PR TITLE
Target branch set up in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
+    target-branch: develop


### PR DESCRIPTION
## Summary
- Target branch set up in dependabot.

## Implementation
- Target branch changed as follows.
  - main → develop