### PR TITLE
Remove --locked option from uv sync in GitHub Actions workflow

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -23,7 +23,7 @@ jobs:
           version: "latest"
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --all-extras --dev
 
       - name: Format Check
         run: |

--- a/.github/workflows/lint_check.yml
+++ b/.github/workflows/lint_check.yml
@@ -23,7 +23,7 @@ jobs:
           version: "latest"
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --all-extras --dev
 
       - name: Lint Check
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
           version: "latest"
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --all-extras --dev
 
       - name: Test
         run: |


### PR DESCRIPTION
## Summary
- Remove `--locked` option from uv sync in GitHub Actions workflow.

## Implementation
-  Remove the `--locked` option from the following.
    - format_check.yml
    - lint_check.yml
    - pytest.yml

## Confirmation
- Confirm pass of workflows.